### PR TITLE
fix(chat): strip "No response requested." marker from chat UI

### DIFF
--- a/Clarc/App/AppState.swift
+++ b/Clarc/App/AppState.swift
@@ -952,8 +952,25 @@ final class AppState {
                 if let start = state.streamingStartDate {
                     state.messages[idx].duration = Date().timeIntervalSince(start)
                 }
+                Self.stripNoOpText(at: idx, in: &state.messages)
             }
             state.streamingStartDate = nil
+        }
+    }
+
+    /// Drop "No response requested." text blocks from the assistant message
+    /// at `idx`. If the message has no blocks left after the strip, remove
+    /// it entirely. Called at turn-finalization sites — the marker is the
+    /// model's response when a turn arrives without a user prompt
+    /// (ScheduleWakeup, hook re-entry) and reads as noise in the chat UI.
+    private static func stripNoOpText(at idx: Int, in messages: inout [ChatMessage]) {
+        guard messages.indices.contains(idx) else { return }
+        messages[idx].blocks.removeAll { block in
+            guard let text = block.text else { return false }
+            return CLIMetaEnvelope.isNoResponseRequested(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if messages[idx].blocks.isEmpty {
+            messages.remove(at: idx)
         }
     }
 
@@ -1329,6 +1346,7 @@ final class AppState {
                     // New Claude turn after receiving tool result — start a new ChatMessage
                     state.messages[idx].isStreaming = false
                     state.messages[idx].finalizeToolCalls()
+                    Self.stripNoOpText(at: idx, in: &state.messages)
                     state.needsNewMessage = false
                     state.messages.append(ChatMessage(role: .assistant, content: buffered, isStreaming: true))
                 } else {
@@ -1376,6 +1394,7 @@ final class AppState {
                         if let idx = state.messages.indices.reversed().first(where: { state.messages[$0].role == .assistant && state.messages[$0].isStreaming }) {
                             state.messages[idx].isStreaming = false
                             state.messages[idx].finalizeToolCalls()
+                            Self.stripNoOpText(at: idx, in: &state.messages)
                         }
                         state.messages.append(ChatMessage(role: .assistant, isStreaming: true))
                         state.needsNewMessage = false

--- a/Packages/Sources/ClarcCore/CLISession/CLILineToBlocksMapper.swift
+++ b/Packages/Sources/ClarcCore/CLISession/CLILineToBlocksMapper.swift
@@ -110,7 +110,10 @@ public enum CLILineToBlocksMapper {
         for part in content {
             switch part {
             case .text(let t):
-                if !t.isEmpty { blocks.append(.text(t)) }
+                guard !t.isEmpty else { continue }
+                let trimmed = t.trimmingCharacters(in: .whitespacesAndNewlines)
+                if CLIMetaEnvelope.isNoResponseRequested(trimmed) { continue }
+                blocks.append(.text(t))
             case .toolUse(let id, let name, let input):
                 blocks.append(.toolCall(ToolCall(id: id, name: name, input: input)))
             case .skip:

--- a/Packages/Sources/ClarcCore/CLISession/CLISessionStore.swift
+++ b/Packages/Sources/ClarcCore/CLISession/CLISessionStore.swift
@@ -504,4 +504,11 @@ public enum CLIMetaEnvelope {
         }
         return false
     }
+
+    /// Detect the model's no-op-turn marker — emitted when a turn arrived
+    /// without a user prompt (e.g. ScheduleWakeup, hook-driven re-entry).
+    /// Renders as a noisy empty bubble in the chat UI; callers strip it.
+    public static func isNoResponseRequested(_ trimmed: String) -> Bool {
+        trimmed == "No response requested." || trimmed == "No response requested"
+    }
 }

--- a/release_notes/v1.2.5.md
+++ b/release_notes/v1.2.5.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Chat: Messages that occasionally went missing during long agent loops or background tool monitoring are now restored automatically. After each turn the app reconciles in-memory state against the CLI session log so any blocks the live stream skipped fill in without an app restart.
+- Chat: Hide the noisy "No response requested." marker the model emits when a turn arrives without a user prompt (e.g. ScheduleWakeup or hook re-entry). It is now stripped from both live streaming and historical session loads.


### PR DESCRIPTION
## Summary

The model occasionally emits the literal text \`No response requested.\` when a turn arrives without a user prompt — typically during \`ScheduleWakeup\` wake-ups, hook-driven re-entry, or background tool monitoring. Clarc rendered each one as an empty noise bubble in the chat history, sometimes stacking up in long autonomous agent loops.

This patch strips the marker so it never reaches the UI.

## Where

- \`CLIMetaEnvelope.isNoResponseRequested(_:)\` — new predicate next to the existing envelope detector.
- \`CLILineToBlocksMapper\` — filter matching text parts when parsing CLI jsonl. Covers initial session loads and the post-\`.result\` reconciliation introduced in #9.
- \`AppState.stripNoOpText(at:in:)\` + three live-stream finalization sites (\`finalizeStreamSession\`, \`flushPendingUpdates\` and \`handlePartialEvent\`'s \`needsNewMessage\` transitions). Filters at turn boundaries only — never mid-stream — so the model is free to write a longer message that happens to start with the marker.

## Behavior

- Text block trim-equal to \`"No response requested."\` (or without the period) is dropped.
- If the message has other blocks (e.g. tool calls), the message is preserved with the text block removed.
- If no blocks remain, the message itself is removed.

## Release notes

\`release_notes/v1.2.5.md\` is included covering this fix plus the jsonl reconciliation from #9.

## Test plan

- [ ] Trigger a long agent loop with \`ScheduleWakeup\` checks; confirm no empty bubbles appear during the run.
- [ ] Reload an existing session that previously contained the marker; confirm the bubbles are gone after the load.
- [ ] Send a normal turn; confirm regular text/tool messages still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)