### PR TITLE
feat: Add visible stop button while streaming

### DIFF
--- a/Packages/Sources/ClarcChatKit/InputBarView.swift
+++ b/Packages/Sources/ClarcChatKit/InputBarView.swift
@@ -155,7 +155,15 @@ struct InputBarView<Accessory: View, TopAccessory: View>: View {
             accessory
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            if !showSlashPopup {
+            if chatBridge.isStreaming {
+                ClaudeSendButton(
+                    isEnabled: true,
+                    systemImageName: "stop.fill",
+                    accessibilityLabel: NSLocalizedString("Stop streaming (cancel response generation)", comment: "Accessibility label for stop streaming button")
+                ) {
+                    Task { await chatBridge.cancelStreaming() }
+                }
+            } else if !showSlashPopup {
                 ClaudeSendButton(
                     isEnabled: !windowState.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         || inputHasMarkedText

--- a/Packages/Sources/ClarcChatKit/InputBarView.swift
+++ b/Packages/Sources/ClarcChatKit/InputBarView.swift
@@ -159,7 +159,7 @@ struct InputBarView<Accessory: View, TopAccessory: View>: View {
                 ClaudeSendButton(
                     isEnabled: true,
                     systemImageName: "stop.fill",
-                    accessibilityLabel: NSLocalizedString("Stop streaming (cancel response generation)", comment: "Accessibility label for stop streaming button")
+                    accessibilityLabel: String(localized: "Stop streaming (cancel response generation)", bundle: .module)
                 ) {
                     Task { await chatBridge.cancelStreaming() }
                 }
@@ -168,6 +168,7 @@ struct InputBarView<Accessory: View, TopAccessory: View>: View {
                     isEnabled: !windowState.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         || inputHasMarkedText
                         || !windowState.attachments.isEmpty,
+                    accessibilityLabel: String(localized: "Send message", bundle: .module),
                     action: sendMessage
                 )
                 .keyboardShortcut(.return, modifiers: .command)

--- a/Packages/Sources/ClarcChatKit/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Sources/ClarcChatKit/Resources/ko.lproj/Localizable.strings
@@ -3,6 +3,8 @@
 // MARK: - InputBarView
 "Attach file" = "파일 첨부";
 "Type a message..." = "메시지를 입력하세요...";
+"Send message" = "메시지 전송";
+"Stop streaming (cancel response generation)" = "스트리밍 중지 (응답 생성 취소)";
 
 // MARK: - FileDiffView
 "Diff" = "Diff";

--- a/Packages/Sources/ClarcCore/Theme/ClaudeTheme.swift
+++ b/Packages/Sources/ClarcCore/Theme/ClaudeTheme.swift
@@ -193,16 +193,25 @@ public struct ClaudeSecondaryButtonStyle: ButtonStyle {
 
 public struct ClaudeSendButton: View {
     public let isEnabled: Bool
+    public let systemImageName: String
+    public let accessibilityLabel: String
     public let action: () -> Void
 
-    public init(isEnabled: Bool, action: @escaping () -> Void) {
+    public init(
+        isEnabled: Bool,
+        systemImageName: String = "arrow.up",
+        accessibilityLabel: String = "Send message",
+        action: @escaping () -> Void
+    ) {
         self.isEnabled = isEnabled
+        self.systemImageName = systemImageName
+        self.accessibilityLabel = accessibilityLabel
         self.action = action
     }
 
     public var body: some View {
         Button(action: action) {
-            Image(systemName: "arrow.up")
+            Image(systemName: systemImageName)
                 .font(.system(size: ClaudeTheme.size(14), weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: 32, height: 32)
@@ -211,6 +220,7 @@ public struct ClaudeSendButton: View {
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
+        .accessibilityLabel(Text(accessibilityLabel))
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a visible stop-state variant for the chat composer button while Claude is streaming.

## Details

- Reuses the existing circular `ClaudeSendButton` styling with configurable SF Symbol and accessibility label.
- Shows a `stop.fill` button whenever `chatBridge.isStreaming` is true.
- Wires the button to the existing `chatBridge.cancelStreaming()` path, which already cancels the active Claude CLI process.

## Validation

- `swift test --package-path Packages` passed.
- `xcodebuild -project Clarc.xcodeproj -scheme Clarc -configuration Debug build` was attempted but this local machine lacks the maintainer Mac Development signing certificate.
- `xcodebuild -project Clarc.xcodeproj -scheme Clarc -configuration Debug CODE_SIGNING_ALLOWED=NO build` was attempted but this local Xcode install is missing the Metal Toolchain required by SwiftTerm (`xcodebuild -downloadComponent MetalToolchain`).
