### PR TITLE
feat: fork conversation from any message

### DIFF
--- a/Clarc/App/AppState.swift
+++ b/Clarc/App/AppState.swift
@@ -720,6 +720,10 @@ final class AppState {
             return
         }
 
+        // Normalize the copied jsonl so the branch shows up in the external
+        // `claude --resume` picker, matching how Clarc-spawned sessions are exposed.
+        await cliStore.exposeToPicker(sid: newSid, cwd: project.path)
+
         guard let forked = await cliStore.loadFullSession(
             sid: newSid,
             cwd: project.path,

--- a/Clarc/App/AppState.swift
+++ b/Clarc/App/AppState.swift
@@ -616,6 +616,10 @@ final class AppState {
             guard let self, let window else { return }
             await self.editAndResend(messageId: messageId, newContent: newContent, in: window)
         }
+        bridge.forkFromHereHandler = { [weak self, weak window] messageId in
+            guard let self, let window else { return }
+            await self.forkFromHere(messageId: messageId, in: window)
+        }
         bridge.fetchRateLimitHandler = {
             await RateLimitService.shared.fetchUsage()
         }
@@ -683,6 +687,52 @@ final class AppState {
         sessionStates.removeValue(forKey: window.newSessionKey)
         lastCommittedReloadKey.removeValue(forKey: window.newSessionKey)
         await sendPrompt(trimmed, skipAppendingUserMessage: true, initialMessages: snapshot, in: window)
+    }
+
+    // MARK: - Fork
+
+    /// Branch the current session at the selected message. Copies the CLI jsonl up
+    /// to (and including) the matching line into a fresh sid so the resumed
+    /// conversation keeps full prior context — the original session is left
+    /// untouched, and the window switches to the new branch.
+    func forkFromHere(messageId: UUID, in window: WindowState) async {
+        guard let sid = window.currentSessionId,
+              !window.pendingPlaceholderIds.contains(sid) else {
+            logger.warning("forkFromHere: no committed session to fork")
+            return
+        }
+        guard let project = window.selectedProject else { return }
+
+        let snapshot = sessionStates[sid]?.allMessages ?? []
+        guard let message = snapshot.first(where: { $0.id == messageId }) else { return }
+
+        if isStreaming(in: window) {
+            await cancelStreaming(in: window)
+        }
+
+        guard let newSid = await cliStore.forkSession(
+            fromSid: sid,
+            cwd: project.path,
+            atMessageTimestamp: message.timestamp,
+            role: message.role
+        ) else {
+            logger.error("forkFromHere: cliStore.forkSession returned nil")
+            return
+        }
+
+        guard let forked = await cliStore.loadFullSession(
+            sid: newSid,
+            cwd: project.path,
+            projectId: project.id
+        ) else {
+            logger.error("forkFromHere: failed to load forked session \(newSid)")
+            return
+        }
+
+        allSessionSummaries.removeAll { $0.id == newSid }
+        allSessionSummaries.insert(forked.summary, at: 0)
+        switchToSession(forked, messages: forked.messages, in: window)
+        window.requestInputFocus = true
     }
 
     // MARK: - Send Message

--- a/Packages/Sources/ClarcChatKit/ChatBridge.swift
+++ b/Packages/Sources/ClarcChatKit/ChatBridge.swift
@@ -27,6 +27,7 @@ public final class ChatBridge {
     public var sendSlashCommandHandler: ((String) async -> Void)?
     public var runTerminalCommandHandler: ((String) async -> Void)?
     public var editAndResendHandler: ((UUID, String) async -> Void)?
+    public var forkFromHereHandler: ((UUID) async -> Void)?
     public var fetchRateLimitHandler: (() async -> RateLimitUsage?)?
 
     // MARK: - Init
@@ -53,6 +54,10 @@ public final class ChatBridge {
 
     public func editAndResend(messageId: UUID, newContent: String) async {
         await editAndResendHandler?(messageId, newContent)
+    }
+
+    public func forkFromHere(messageId: UUID) async {
+        await forkFromHereHandler?(messageId)
     }
 
     public func fetchRateLimit() async -> RateLimitUsage? {

--- a/Packages/Sources/ClarcChatKit/MessageBubble.swift
+++ b/Packages/Sources/ClarcChatKit/MessageBubble.swift
@@ -218,9 +218,6 @@ struct MessageBubble: View {
                         userActionButton(systemName: isCopied ? "checkmark" : "doc.on.doc") {
                             copyToClipboard(message.content, feedback: $isCopied)
                         }
-                        userActionButton(systemName: "arrow.triangle.branch") {
-                            Task { await chatBridge.forkFromHere(messageId: message.id) }
-                        }
                         userActionButton(systemName: "pencil") {
                             editText = message.content
                             isEditing = true
@@ -329,13 +326,17 @@ struct MessageBubble: View {
     private func userActionButton(systemName: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
-                .font(.system(size: ClaudeTheme.messageSize(9), weight: .medium))
+                .font(.system(size: ClaudeTheme.messageSize(11), weight: .medium))
                 .foregroundStyle(ClaudeTheme.textSecondary)
-                .frame(width: 20, height: 20)
-                .background(ClaudeTheme.surfaceSecondary.opacity(0.5), in: RoundedRectangle(cornerRadius: 5))
+                .frame(width: 24, height: 24)
+                .background(ClaudeTheme.surfaceSecondary, in: RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(ClaudeTheme.border, lineWidth: 0.5)
+                )
         }
         .buttonStyle(.plain)
-        .opacity(0.6)
+        .opacity(0.8)
     }
 
     // MARK: - Transient Tool Helpers

--- a/Packages/Sources/ClarcChatKit/MessageBubble.swift
+++ b/Packages/Sources/ClarcChatKit/MessageBubble.swift
@@ -218,6 +218,9 @@ struct MessageBubble: View {
                         userActionButton(systemName: isCopied ? "checkmark" : "doc.on.doc") {
                             copyToClipboard(message.content, feedback: $isCopied)
                         }
+                        userActionButton(systemName: "arrow.triangle.branch") {
+                            Task { await chatBridge.forkFromHere(messageId: message.id) }
+                        }
                         userActionButton(systemName: "pencil") {
                             editText = message.content
                             isEditing = true
@@ -264,9 +267,12 @@ struct MessageBubble: View {
         .bubbleStyle(.assistant)
         .overlay(alignment: .bottomTrailing) {
             if hoveredBlockId == blockId && !message.isStreaming {
-                copyButton(for: text)
-                    .padding(6)
-                    .transition(.opacity.animation(.easeInOut(duration: 0.15)))
+                HStack(spacing: 4) {
+                    copyButton(for: text)
+                    forkButton()
+                }
+                .padding(6)
+                .transition(.opacity.animation(.easeInOut(duration: 0.15)))
             }
         }
         .onHover { hoveredBlockId = $0 ? blockId : nil }
@@ -298,6 +304,25 @@ struct MessageBubble: View {
                 )
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func forkButton() -> some View {
+        Button {
+            Task { await chatBridge.forkFromHere(messageId: message.id) }
+        } label: {
+            Image(systemName: "arrow.triangle.branch")
+                .font(.system(size: ClaudeTheme.messageSize(11), weight: .medium))
+                .foregroundStyle(ClaudeTheme.textSecondary)
+                .frame(width: 26, height: 26)
+                .background(ClaudeTheme.surfaceSecondary, in: RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(ClaudeTheme.border, lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(String(localized: "Fork from here", bundle: .module))
     }
 
     @ViewBuilder

--- a/Packages/Sources/ClarcChatKit/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Sources/ClarcChatKit/Resources/ko.lproj/Localizable.strings
@@ -137,6 +137,7 @@
 "Show more" = "더 보기";
 "Copy Message" = "메시지 복사";
 "Edit Message" = "메시지 편집";
+"Fork from here" = "여기서 분기";
 
 // MARK: - ChatView
 "Manage shortcuts" = "단축키 관리";

--- a/Packages/Sources/ClarcCore/CLISession/CLISessionStore.swift
+++ b/Packages/Sources/ClarcCore/CLISession/CLISessionStore.swift
@@ -430,6 +430,139 @@ public actor CLISessionStore {
         await PickerExposer.normalize(jsonlAt: await jsonlURL(sid: sid, cwd: cwd))
     }
 
+    // MARK: - Fork
+
+    /// Branch a session at the line matching `messageTimestamp`/`role`. Copies the
+    /// originating jsonl up to that line (plus any immediately-following tool_result
+    /// lines that resolve tool_use blocks in the kept assistant turn), rewrites every
+    /// `sessionId` field to a fresh UUID, and writes the result as a new jsonl in the
+    /// same projects directory. The CLI then accepts the new sid via `--resume`,
+    /// preserving full prior context for the fork.
+    ///
+    /// Returns the new session id, or nil if the source jsonl is unreadable or no
+    /// matching line is found.
+    public func forkSession(
+        fromSid sid: String,
+        cwd: String,
+        atMessageTimestamp messageTimestamp: Date,
+        role: Role
+    ) async -> String? {
+        let originalURL = await jsonlURL(sid: sid, cwd: cwd)
+        let directory = originalURL.deletingLastPathComponent()
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: originalURL, options: .mappedIfSafe)
+        } catch {
+            logger.error("forkSession read failed for \(sid, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        guard let content = String(data: data, encoding: .utf8) else { return nil }
+
+        let rawLines = content.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        var decoded: [CLISessionLine?] = Array(repeating: nil, count: rawLines.count)
+        for (i, raw) in rawLines.enumerated() {
+            guard let lineData = raw.data(using: .utf8) else { continue }
+            decoded[i] = try? decoder.decode(CLISessionLine.self, from: lineData)
+        }
+
+        // Match the last line of the requested role whose timestamp == messageTimestamp.
+        // CLI emits sub-second precision timestamps, so collisions across visible turns
+        // are vanishingly rare.
+        var truncIndex: Int?
+        for (i, line) in decoded.enumerated() {
+            switch (line, role) {
+            case (.user(let u)?, .user):
+                if u.isMeta || u.isSidechain { continue }
+                if let ts = u.timestamp, ts == messageTimestamp {
+                    truncIndex = i
+                }
+            case (.assistant(let a)?, .assistant):
+                if a.isSidechain { continue }
+                if let ts = a.timestamp, ts == messageTimestamp {
+                    truncIndex = i
+                }
+            default:
+                continue
+            }
+        }
+        guard let truncIndex else {
+            logger.error("forkSession: no line matched timestamp for sid \(sid, privacy: .public)")
+            return nil
+        }
+
+        var endIndex = truncIndex
+
+        // For assistant turns with tool_use blocks, extend through the immediately
+        // following tool_result user lines so the resumed conversation has all
+        // tool_uses resolved. Stop as soon as we hit fresh user text or another
+        // assistant turn — those belong to the post-fork timeline.
+        if case .assistant(let assistantLine)? = decoded[truncIndex] {
+            var pendingToolIds: Set<String> = []
+            for part in assistantLine.message.content {
+                if case .toolUse(let id, _, _) = part { pendingToolIds.insert(id) }
+            }
+            if !pendingToolIds.isEmpty {
+                var i = truncIndex + 1
+                while i < decoded.count {
+                    guard let next = decoded[i] else { i += 1; continue }
+                    switch next {
+                    case .user(let u):
+                        if u.isMeta || u.isSidechain { i += 1; continue }
+                        guard case .parts(let parts) = u.message.content else {
+                            i = decoded.count  // string content = fresh user input
+                            continue
+                        }
+                        var hasText = false
+                        var resolvedAny = false
+                        for p in parts {
+                            switch p {
+                            case .text(let t):
+                                if !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                                   !CLIMetaEnvelope.isEnvelope(t.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                                    hasText = true
+                                }
+                            case .toolResult(let id, _, _):
+                                if pendingToolIds.contains(id) { resolvedAny = true }
+                            case .unknown:
+                                continue
+                            }
+                        }
+                        if hasText { i = decoded.count; continue }
+                        if resolvedAny { endIndex = i }
+                        i += 1
+                    case .assistant:
+                        i = decoded.count
+                    case .skip:
+                        i += 1
+                    }
+                }
+            }
+        }
+
+        let newSid = UUID().uuidString.lowercased()
+        let kept = rawLines[0...endIndex].map { Self.rewriteSessionId(in: $0, to: newSid) }
+        let newContent = kept.joined(separator: "\n") + "\n"
+
+        let newURL = directory.appendingPathComponent("\(newSid).jsonl")
+        do {
+            try newContent.data(using: .utf8)?.write(to: newURL, options: .atomic)
+            logger.debug("Forked session \(sid, privacy: .public) → \(newSid, privacy: .public) (\(kept.count, privacy: .public) lines)")
+            return newSid
+        } catch {
+            logger.error("forkSession write failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    private static func rewriteSessionId(in line: String, to newSid: String) -> String {
+        line.replacingOccurrences(
+            of: #""sessionId"\s*:\s*"[^"]*""#,
+            with: "\"sessionId\":\"\(newSid)\"",
+            options: .regularExpression
+        )
+    }
+
     // MARK: - Deletion
 
     /// Remove the CLI-owned jsonl for a session.


### PR DESCRIPTION

<img width="376" height="106" alt="image" src="https://github.com/user-attachments/assets/4b7a9baa-50c9-40ac-8942-3c6359731d77" />


## Summary
- Adds a **Fork from here** hover button on every committed message (next to Copy / Pencil for user bubbles, next to Copy for assistant bubbles).
- Forking copies the Claude CLI's own jsonl up to and including the chosen line into a fresh sid (rewriting `sessionId` per kept line), then switches the window to the new branch. The original session is untouched, and the model keeps full prior context on resume because the next `claude --resume <newSid>` reads the truncated jsonl.
- For assistant turns containing `tool_use` blocks, the copy extends through immediately-following `tool_result` user lines so the resumed conversation does not begin with an orphaned `tool_use`. Stops at the next fresh user prompt or assistant turn.

## How it works
- `CLISessionStore.forkSession(fromSid:cwd:atMessageTimestamp:role:)` reads the source jsonl, matches the target line by `(timestamp, role)`, sweeps forward through tool-result-only user lines, rewrites every `"sessionId":"..."` to a fresh UUID, writes a sibling `{newSid}.jsonl`, and returns the new sid.
- `AppState.forkFromHere(messageId:in:)` cancels any active stream, calls `cliStore.forkSession`, loads the new session via `cliStore.loadFullSession`, inserts the summary, switches the window, and focuses the input.
- `ChatBridge.forkFromHereHandler` plumbs the action from the UI to `AppState`.
- Match key is `(timestamp, role)` — CLI emits sub-second precision so collisions across visible turns are vanishingly rare.

## Test plan
- [ ] Right-click / hover on a user message → click the branch icon → new session appears at the top of the sidebar, current window switches to it, prior turns are visible.
- [ ] Fork from an assistant message, send a new prompt → the model responds with full prior context (i.e. it "remembers" the earlier conversation).
- [ ] Fork from an assistant message whose turn ends with `Edit`/`Write`/`Bash` (`tool_use`) → resumed session does not error on the next prompt; the tool_use is shown as resolved.
- [ ] Original session remains intact after forking (open it from the sidebar — all post-fork messages still present).
- [ ] Try forking from a message inside a streaming session — should cancel stream first, then fork.
