### PR TITLE
i18n(zh-Hans) + fix(cli): Simplified Chinese & shell env passthrough

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,27 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode (latest stable)
+      - name: Install latest Xcode (has Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show toolchain
         run: |
-          ls -d /Applications/Xcode_*.app | head -1
-          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | head -1)/Contents/Developer"
           xcodebuild -version
+          swift --version
+
+      - name: Resolve SwiftPM packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Clarc.xcodeproj \
+            -scheme Clarc
 
       - name: Build (Release, unsigned)
         run: |
@@ -32,13 +42,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="" \
-            build 2>&1 | tail -50
+            build 2>&1 | tail -60
 
       - name: Package .app
         run: |
           APP="build/Build/Products/Release/Clarc.app"
           test -d "$APP" || (echo "Clarc.app not found"; ls -la build/Build/Products/Release/; exit 1)
-          # Verify zh-Hans.lproj made it into the bundle
           test -d "$APP/Contents/Resources/zh-Hans.lproj" || (echo "zh-Hans.lproj missing from bundle!"; exit 1)
           cd build/Build/Products/Release
           ditto -c -k --sequesterRsrc --keepParent Clarc.app Clarc.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: build
+
+on:
+  push:
+    branches: [i18n-zh-Hans-and-shell-env]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode (latest stable)
+        run: |
+          ls -d /Applications/Xcode_*.app | head -1
+          sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | head -1)/Contents/Developer"
+          xcodebuild -version
+
+      - name: Build (Release, unsigned)
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Clarc.xcodeproj \
+            -scheme Clarc \
+            -configuration Release \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="" \
+            build 2>&1 | tail -50
+
+      - name: Package .app
+        run: |
+          APP="build/Build/Products/Release/Clarc.app"
+          test -d "$APP" || (echo "Clarc.app not found"; ls -la build/Build/Products/Release/; exit 1)
+          # Verify zh-Hans.lproj made it into the bundle
+          test -d "$APP/Contents/Resources/zh-Hans.lproj" || (echo "zh-Hans.lproj missing from bundle!"; exit 1)
+          cd build/Build/Products/Release
+          ditto -c -k --sequesterRsrc --keepParent Clarc.app Clarc.zip
+          shasum -a 256 Clarc.zip | tee Clarc.zip.sha256
+
+      - name: Upload .app
+        uses: actions/upload-artifact@v4
+        with:
+          name: Clarc-app
+          path: build/Build/Products/Release/Clarc.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/Clarc.xcodeproj/project.pbxproj
+++ b/Clarc.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 			knownRegions = (
 				en,
 				ko,
+				zh-Hans,
 				Base,
 			);
 			mainGroup = E673352F2F7356F600FD26C7;

--- a/Clarc/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Clarc/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,515 @@
+/* Simplified Chinese — zh-Hans localization for main app */
+
+/* English — base localization for main app */
+
+
+// MARK: - ClarcApp
+"New Chat" = "新建对话";
+"Check for Updates..." = "检查更新...";
+"Theme" = "主题";
+
+
+// MARK: - SettingsView
+"General" = "通用";
+"Message" = "消息";
+"Focus Mode" = "专注模式";
+"Enable Focus Mode" = "启用专注模式";
+"focus.mode.desc" = "隐藏流式输出气泡,仅在历史中显示完整回复。";
+"Auto-preview Attachments" = "自动预览附件";
+"auto.preview.desc" = "启用后,粘贴以下类型的内容会自动生成附件预览。禁用后,内容将以纯文本形式插入。";
+"URL links" = "网址链接";
+"File paths" = "文件路径";
+"Images" = "图片";
+"Long text (200+ characters)" = "长文本 (200 字符以上)";
+"Shortcuts" = "快捷按钮";
+"Browse and manage Claude Code skills" = "浏览并管理 Claude Code 技能";
+"Default Model" = "默认模型";
+"Used for new sessions. You can override the model per session from the toolbar." = "用于新会话。可在工具栏按会话单独覆盖。";
+"Default Permission Mode" = "默认权限模式";
+"Used for new sessions. You can override the permission mode per session from the toolbar." = "用于新会话。可在工具栏按会话单独覆盖。";
+"Default Effort Level" = "默认思考强度";
+"Used for new sessions. You can override the effort level per session from the toolbar." = "用于新会话。可在工具栏按会话单独覆盖。";
+"Font Size" = "字号";
+"Interface" = "界面";
+"Messages" = "消息";
+"Default" = "默认";
+"Reset" = "重置";
+"font.size.hint" = "分别调整界面与消息的字号。";
+"Notifications" = "通知";
+"Notify when response completes" = "回复完成时通知";
+"Sends a system notification while Clarc is in the background." = "Clarc 在后台时,发送系统通知。";
+"Open Source" = "开源";
+"Response complete" = "回复已完成";
+
+
+// MARK: - MainView / ProjectWindowView
+"Manage GitHub Repos" = "管理 GitHub 仓库";
+"Connect GitHub" = "连接 GitHub";
+"Add Project" = "添加项目";
+"History" = "历史";
+"Files" = "文件";
+"Select a Project" = "选择一个项目";
+"Select a project from the sidebar or add a new one." = "从侧栏选择一个项目,或新建一个项目。";
+"Error" = "错误";
+"OK" = "好";
+"Manage Slash Commands" = "管理斜杠命令";
+"Manage Shortcuts" = "管理快捷按钮";
+"Claude Code Terminal" = "Claude Code 终端";
+"Skill Marketplace" = "技能市场";
+"Change Theme" = "切换主题";
+"User Guide" = "使用指南";
+"Claude Code" = "Claude Code";
+"Skip Permissions: ON" = "跳过权限检查:开";
+"Skip Permissions: OFF" = "跳过权限检查:关";
+"Select Model" = "选择模型";
+"Select Effort Level" = "选择思考强度";
+"↑↓ Select  ↵ Confirm  esc Cancel" = "↑↓ 选择  ↵ 确认  esc 取消";
+
+
+// MARK: - SkillMarketView
+"Refresh" = "刷新";
+"Close" = "关闭";
+"Search skills..." = "搜索技能...";
+"All" = "全部";
+"Installed" = "已安装";
+"Loading catalog..." = "正在加载目录...";
+"No results found" = "未找到结果";
+"Installing..." = "正在安装...";
+"Failed" = "失败";
+"Back" = "返回";
+"Author" = "作者";
+"Market" = "市场";
+"Category" = "分类";
+"Homepage" = "主页";
+"Install Command" = "安装命令";
+"Remove" = "移除";
+"Retry" = "重试";
+"Install" = "安装";
+
+
+// MARK: - GitHubSheet / GitHubRepoListView
+"GitHub" = "GitHub";
+"Connect GitHub to\nimport repos instantly" = "连接 GitHub\n一键导入仓库";
+"Search repos..." = "搜索仓库...";
+"Loading repos..." = "正在加载仓库...";
+"No repos found" = "未找到仓库";
+"Don't see your org repos? →" = "看不到你的组织仓库?→";
+"Don't see your org repos?" = "看不到你的组织仓库?";
+"Configure org access →" = "配置组织访问权限 →";
+"Added" = "已添加";
+"Add" = "添加";
+"Add to projects" = "添加到项目";
+
+
+// MARK: - FileTreeView
+"Search Files (⌘F)" = "搜索文件 (⌘F)";
+"Search filename..." = "搜索文件名...";
+"Loading..." = "正在加载...";
+"No results for '%@'" = "没有匹配 '%@' 的结果";
+"%d files" = "%d 个文件";
+"Unable to load files" = "无法加载文件";
+"Add path to message" = "将路径加入消息";
+"Show in Finder" = "在访达中显示";
+
+
+// MARK: - ProjectListView
+"Projects" = "项目";
+"Rename Project" = "重命名项目";
+"Delete Project" = "删除项目";
+"This will remove the project from Clarc. The files on disk will not be deleted." = "这将从 Clarc 中移除该项目,磁盘上的文件不会被删除。";
+"Project name" = "项目名";
+
+
+// MARK: - HistoryListView
+"Show current project only" = "仅显示当前项目";
+"Show all projects" = "显示所有项目";
+"Delete All" = "全部删除";
+"Delete" = "删除";
+"Cancel" = "取消";
+"All sessions in the current project will be deleted. This action cannot be undone." = "将删除当前项目下的全部会话,此操作不可撤销。";
+"All sessions will be deleted. This action cannot be undone." = "将删除全部会话,此操作不可撤销。";
+"Rename Session" = "重命名会话";
+"Session name" = "会话名";
+"Rename" = "重命名";
+"Response in progress in the background" = "回复正在后台进行";
+"Unpin" = "取消置顶";
+"Pin" = "置顶";
+"No chat history" = "暂无对话记录";
+
+
+// MARK: - GitStatusView
+"Checking..." = "检查中...";
+"Not a Git repository" = "不是 Git 仓库";
+"No changes" = "无变更";
+"%d changed" = "%d 处变更";
+"Failed to check status" = "检查状态失败";
+"Local" = "本地";
+"Remote (origin)" = "远程 (origin)";
+"No local branches" = "无本地分支";
+"No remote branches" = "无远程分支";
+"Switch Branch" = "切换分支";
+
+
+// MARK: - FileInspectorView
+"Preview" = "预览";
+"Edit" = "编辑";
+"Copied" = "已复制";
+"Copy" = "复制";
+"loading..." = "加载中...";
+"Binary file — preview not available" = "二进制文件 — 无法预览";
+"File is too large (>1MB)" = "文件过大 (>1MB)";
+"Read failed: %@" = "读取失败:%@";
+"Save failed: %@" = "保存失败:%@";
+
+
+// MARK: - ChatToolbarControls
+"Permission Mode" = "权限模式";
+"Ask" = "询问";
+"Accept Edits" = "接受编辑";
+"Plan" = "计划";
+"Auto" = "自动";
+"Bypass" = "跳过";
+"Model Picker" = "模型选择器";
+"Effort Picker" = "思考强度选择器";
+"Auto Effort" = "自动思考";
+"Low" = "低";
+"Medium" = "中";
+"High" = "高";
+"XHigh" = "特高";
+"Max" = "最高";
+"Permission mode: %@" = "权限模式:%@";
+"Effort level (--effort)" = "思考强度 (--effort)";
+
+
+// MARK: - PermissionModal
+"Permission Request" = "权限请求";
+"Command" = "命令";
+"File" = "文件";
+"Input" = "输入";
+"Auto-deny in %@" = "%@ 后自动拒绝";
+"Deny" = "拒绝";
+"Allow" = "允许";
+"Allow this tool for the session" = "本次会话允许此工具";
+"Always allow this command" = "始终允许此命令";
+
+
+// MARK: - OnboardingView
+"Claude CLI Installation Check" = "Claude CLI 安装检查";
+"Installed — %@" = "已安装 — %@";
+"Claude CLI not found" = "未找到 Claude CLI";
+"Install command:" = "安装命令:";
+"Check Again" = "重新检查";
+"Get Started" = "开始使用";
+"Share session history with the terminal CLI in ~/.claude/projects/. Turn off to keep Clarc sessions separate. You can change this later in Settings." = "与终端 CLI 共享 ~/.claude/projects/ 中的会话历史。关闭后可保持 Clarc 会话独立。稍后可在设置中调整。";
+
+
+// MARK: - GitHubLoginView
+"Connect GitHub to fetch your repo list and add projects with a single click." = "连接 GitHub 以获取你的仓库列表,一键添加为项目。";
+"Sign in with GitHub" = "使用 GitHub 登录";
+"Authentication Code" = "身份验证代码";
+"Copy Code" = "复制代码";
+"Authenticate on GitHub" = "在 GitHub 上完成认证";
+"Waiting for authentication..." = "正在等待认证...";
+"Connected" = "已连接";
+
+
+// MARK: - InspectorTabControl
+"Memo" = "备忘";
+"Terminal" = "终端";
+
+
+// MARK: - Model Descriptions
+"model.desc.default" = "回退到当前账号类型推荐的模型";
+"model.desc.best" = "当前能力最强的模型,等同于 Opus";
+"model.desc.opus" = "最新的 Opus 模型,适合复杂推理任务";
+"model.desc.opus1m" = "Opus,支持 100 万 token 上下文窗口,适合长会话";
+"model.desc.opusplan" = "计划阶段使用 Opus,执行阶段切换到 Sonnet";
+"model.desc.sonnet" = "最新的 Sonnet 模型,适合日常编程任务";
+"model.desc.sonnet1m" = "Sonnet,支持 100 万 token 上下文窗口,适合长会话";
+"model.desc.haiku" = "快速高效的模型,适合简单任务";
+
+
+// MARK: - Permission Mode Descriptions
+"perm.desc.default" = "在每次文件编辑或 shell 命令前提示。适合敏感任务或初次使用。";
+"perm.desc.acceptEdits" = "自动批准文件编辑和常见文件系统命令 (mkdir、touch、mv、cp)。其他 shell 命令仍会提示。";
+"perm.desc.plan" = "只读模式。Claude 调研并给出方案,不进行任何修改。其他操作的提示与默认模式相同。";
+"perm.desc.auto" = "运行时不出现权限提示。后台分类器会在执行前审查每个操作的安全性。";
+"perm.desc.bypassPermissions" = "跳过所有权限检查和安全网关。仅在无网络访问的隔离容器或虚拟机中使用。";
+
+
+// MARK: - Effort Level Descriptions
+"effort.desc.auto" = "使用模型默认的思考强度,由当前模型和订阅自动决定。";
+"effort.desc.low" = "留给短小、范围明确、对延迟敏感、对智能要求不高的任务。";
+"effort.desc.medium" = "减少 token 消耗,适合可接受一定智能损失的成本敏感场景。";
+"effort.desc.high" = "在 token 消耗与智能之间取得平衡,是智能敏感任务的最低推荐档位。";
+"effort.desc.xhigh" = "在大多数编程与代理任务中效果最好。Opus 4.7 上的推荐默认档。";
+"effort.desc.max" = "无 token 限制的深度推理,仅在当前会话生效。适合高难度复杂任务。";
+
+
+// MARK: - AppState
+"Previous conversation has been compacted" = "上一段对话已压缩";
+"No response received" = "未收到回复";
+"Done" = "完成";
+
+
+// MARK: - UserManualView
+// Topic titles
+"About Clarc" = "关于 Clarc";
+"Status Line" = "状态栏";
+"Project Management" = "项目管理";
+"Chat Basics" = "对话基础";
+"Keyboard Shortcuts" = "键盘快捷键";
+"Slash Commands" = "斜杠命令";
+"File & Image Attachments" = "文件与图片附件";
+"Shortcut Buttons" = "快捷按钮";
+"Inspector Panel" = "检查器面板";
+"GitHub Integration" = "GitHub 集成";
+"Permission Requests" = "权限请求";
+
+// Overview
+"What is Clarc?" = "Clarc 是什么?";
+"A native macOS desktop client for the Claude Code CLI. Use all Claude Code features via a polished GUI without needing a terminal." = "Claude Code CLI 的原生 macOS 桌面客户端。无需终端,通过精致的图形界面使用 Claude Code 的全部功能。";
+"Main Layout" = "主界面布局";
+"The left sidebar has History and Files tabs. Project tabs appear at the top of the chat area — click to switch projects. The right inspector panel contains the Terminal and Memo tabs." = "左侧栏包含“历史”和“文件”选项卡。项目选项卡位于对话区顶部,点击可切换项目。右侧检查器面板包含“终端”和“备忘”选项卡。";
+"Chat is disabled when no project is selected." = "未选择项目时对话功能不可用。";
+"Top Toolbar" = "顶部工具栏";
+"The toolbar contains: New Chat, Manage Slash Commands, Manage Shortcut Buttons, Skip Permissions toggle, Model picker, Inspector panel toggle, Settings, and the GitHub integration button." = "工具栏包含:新建对话、管理斜杠命令、管理快捷按钮、跳过权限检查开关、模型选择器、检查器面板开关、设置,以及 GitHub 集成按钮。";
+
+// Project Management
+"Adding a Project" = "添加项目";
+"Click the + button at the top of the sidebar or drag a folder from Finder. Claude Code uses that folder as its working directory." = "点击侧栏顶部的 + 按钮,或将文件夹从访达拖入。Claude Code 会将该文件夹作为工作目录。";
+"Project Tabs" = "项目选项卡";
+"Project tabs appear at the top of the chat area. Click a tab to switch projects. You can switch even while Claude is streaming — the active stream continues in the background." = "项目选项卡位于对话区顶部。点击即可切换项目。即使 Claude 正在流式输出也可以切换,当前任务会在后台继续。";
+"Dedicated Project Window" = "独立项目窗口";
+"Double-click a project tab to open it in its own independent window. Each window manages its own sessions independently, allowing you to work on multiple projects at once." = "双击项目选项卡可在独立窗口中打开。每个窗口独立管理各自的会话,可同时处理多个项目。";
+"In a dedicated project window, only the project name is shown — there are no project tabs." = "在独立项目窗口中仅显示项目名,不会显示项目选项卡。";
+"Sidebar Tabs" = "侧栏选项卡";
+"History tab: shows previous conversations\nFiles tab: browse the project file tree" = "“历史”选项卡:显示过往对话\n“文件”选项卡:浏览项目文件树";
+"Go to History tab" = "切换到“历史”选项卡";
+"Go to Files tab" = "切换到“文件”选项卡";
+"Files tab + activate search" = "“文件”选项卡 + 激活搜索";
+"History Management" = "历史记录管理";
+"Right-click a session in the History tab for context menu options." = "在“历史”选项卡中右键单击会话可打开上下文菜单。";
+"Pin / Unpin — pinned sessions stay at the top of the list" = "置顶 / 取消置顶 — 置顶的会话会始终显示在列表顶部";
+"Rename — change the session title" = "重命名 — 修改会话标题";
+"Delete — remove the session" = "删除 — 移除该会话";
+"Use the trash icon in the History header to delete all sessions at once." = "可使用“历史”顶部的垃圾桶图标一次删除所有会话。";
+"File Inspector" = "文件检查器";
+"Click any file in the Files tab to preview it with syntax highlighting. Press the pencil button to enter edit mode and modify the file directly." = "在“文件”选项卡中点击任意文件即可带语法高亮预览。点击铅笔按钮进入编辑模式即可直接修改文件。";
+"Save file changes" = "保存文件修改";
+"Exit edit mode" = "退出编辑模式";
+"Files larger than 1 MB cannot be previewed." = "大于 1 MB 的文件无法预览。";
+"Git Status" = "Git 状态";
+"The number of changed files is shown at the bottom of the sidebar." = "变更文件数显示在侧栏底部。";
+
+// Chat Basics
+"Sending Messages" = "发送消息";
+"Type a message in the input field and press Return or the send button." = "在输入框中输入消息,按回车或点击发送按钮。";
+"Send message" = "发送消息";
+"Send message (alternative)" = "发送消息 (备选)";
+"Insert line break" = "插入换行";
+"Stop streaming (cancel response generation)" = "停止流式输出 (取消回复生成)";
+"Message Queue" = "消息队列";
+"You can send messages even while Claude is responding. New messages are queued automatically and sent once the current response finishes. Queued messages appear as a badge above the input field — click the × on each item to remove it from the queue." = "即使 Claude 正在回复也可以发送消息。新消息会自动加入队列,在当前回复结束后依次发送。已排队的消息以徽标形式显示在输入框上方 — 点击每项上的 × 可将其移出队列。";
+"Recalling Previous Messages" = "调用历史消息";
+"When the input field is empty, use ↑/↓ to navigate your message history." = "输入框为空时,使用 ↑/↓ 在消息历史中切换。";
+"Recall previous message" = "调用上一条消息";
+"Next message / clear input" = "下一条消息 / 清空输入";
+"Changing the Model" = "切换模型";
+"Use the model dropdown at the top of the chat area to switch Claude models." = "使用对话区顶部的模型下拉框切换 Claude 模型。";
+"Skip Permissions" = "跳过权限检查";
+"Toggle the shield icon at the top of the chat to auto-approve all permission prompts. Use with caution." = "切换对话顶部的盾牌图标可自动批准所有权限提示。请谨慎使用。";
+"Normal mode — permission prompts appear as usual" = "普通模式 — 按正常流程出现权限提示";
+"Skip mode — all permissions auto-approved" = "跳过模式 — 全部权限自动批准";
+"Only enable Skip Permissions on projects you fully trust." = "仅在完全信任的项目上启用“跳过权限检查”。";
+
+// Keyboard Shortcuts
+"Global Shortcuts" = "全局快捷键";
+"Start new chat" = "新建对话";
+"Close current window" = "关闭当前窗口";
+"Sidebar — History tab (expands sidebar if hidden)" = "侧栏 — “历史”选项卡 (若隐藏则展开侧栏)";
+"Sidebar — Files tab (expands sidebar if hidden)" = "侧栏 — “文件”选项卡 (若隐藏则展开侧栏)";
+"Toggle left sidebar" = "切换左侧栏";
+"Toggle right inspector panel" = "切换右侧检查器面板";
+"Sidebar — Files tab + search" = "侧栏 — “文件”选项卡 + 搜索";
+"Project tab — open in dedicated window" = "项目选项卡 — 在独立窗口中打开";
+"Input Field Shortcuts" = "输入框快捷键";
+"Line break" = "换行";
+"Close popup / stop streaming" = "关闭弹窗 / 停止流式输出";
+"Select popup item or navigate message history" = "选择弹窗项 / 在消息历史中切换";
+"Autocomplete slash command / @ file" = "自动补全斜杠命令 / @ 文件";
+"Slash Command Popup" = "斜杠命令弹窗";
+"Select item" = "选择项";
+"Execute command" = "执行命令";
+"Execute selected command" = "执行选中的命令";
+"View command details" = "查看命令详情";
+"Autocomplete command" = "自动补全命令";
+"Close popup" = "关闭弹窗";
+"@ File Popup" = "@ 文件弹窗";
+"Insert file path" = "插入文件路径";
+"Insert file path into message" = "将文件路径插入消息";
+
+// Slash Commands
+"What are Slash Commands?" = "什么是斜杠命令?";
+"Type / in the input field to open a popup list of available commands. Slash commands let you quickly trigger Claude Code CLI operations without typing them manually." = "在输入框中输入 / 即可打开可用命令的弹窗列表。斜杠命令可快速触发 Claude Code CLI 的操作,无需手动输入完整命令。";
+"How to Use" = "使用方法";
+"Type / to open the popup, then continue typing to filter results. Use ↑/↓ to navigate." = "输入 / 打开弹窗,然后继续输入以过滤结果。使用 ↑/↓ 切换。";
+"Interactive Commands" = "交互式命令";
+"Some commands (such as /config, /permissions, /model) open in a full interactive terminal popup sheet, where you can use the interactive CLI interface. The popup closes automatically when the command finishes." = "部分命令 (例如 /config、/permissions、/model) 会在全屏交互式终端弹窗中打开,可使用 CLI 的交互界面。命令结束后弹窗会自动关闭。";
+"Managing Commands" = "命令管理";
+"Click the / button in the toolbar, or open Settings → Slash Commands to add, edit, delete, or disable custom commands. Built-in commands can be edited and enabled or disabled in the app." = "点击工具栏中的 / 按钮,或打开“设置 → 斜杠命令”以添加、编辑、删除或禁用自定义命令。内置命令也可在应用内编辑并启用 / 禁用。";
+"JSON import/export backs up or shares custom commands only. Built-in commands in imported files are ignored." = "JSON 导入 / 导出仅备份或分享自定义命令,导入文件中的内置命令会被忽略。";
+
+// File & Image Attachments
+"Attaching Files" = "附加文件";
+"Click the clip icon to the left of the input field, or drag and drop files onto the input field. When dragging, the input field border highlights in the accent color to show the drop zone." = "点击输入框左侧的回形针图标,或将文件拖放到输入框上。拖动时,输入框边框会以主题色高亮显示放置区域。";
+"Clipboard Detection" = "剪贴板识别";
+"Pasting (⌘V) is smart — Clarc detects what's in the clipboard and handles it automatically." = "粘贴 (⌘V) 是智能的 — Clarc 会自动检测剪贴板内容并作出相应处理。";
+"Image data (PNG/TIFF) → attached as an image" = "图片数据 (PNG/TIFF) → 作为图片附加";
+"File path → attached as a file" = "文件路径 → 作为文件附加";
+"URL → attached as a URL reference" = "URL → 作为网址引用附加";
+"Long text (>2 KB) → converted to a text attachment" = "长文本 (>2 KB) → 转换为文本附件";
+"Screenshots can be pasted directly — they are automatically attached as images." = "可直接粘贴屏幕截图 — 会自动作为图片附加。";
+"@ File References" = "@ 文件引用";
+"Type @ in the input field to open a project file search popup. Files are filtered in real time as you type." = "在输入框中输入 @ 可打开项目文件搜索弹窗,边输入边实时过滤。";
+
+// Shortcut Buttons
+"What are Shortcut Buttons?" = "什么是快捷按钮?";
+"Quick-access buttons shown at the top of the chat area. Run frequently used messages or shell commands with a single click." = "显示在对话区顶部的快速访问按钮,一键运行常用的消息或 shell 命令。";
+"Adding a Shortcut" = "添加快捷按钮";
+"Click the ⚡ button in the toolbar to open the Shortcut Manager, or press the + button on the right side of the shortcut bar. You can set a name, message/command, icon, and color." = "点击工具栏中的 ⚡ 按钮打开快捷按钮管理器,或点击快捷按钮栏右侧的 + 按钮。可设置名称、消息/命令、图标和颜色。";
+"Terminal Command Mode" = "终端命令模式";
+"Enable the \"Run as terminal command\" option to execute the shortcut as a shell command in the inspector terminal instead of sending it as a chat message. The project directory is used as the working directory." = "启用“以终端命令运行”选项后,快捷按钮会在检查器终端中作为 shell 命令执行,而不是作为对话消息发送。项目目录会作为工作目录。";
+"Managing Shortcuts" = "快捷按钮管理";
+"Open Settings → Shortcuts to reorder, edit, or delete shortcuts. Shortcut configurations are saved per project." = "打开“设置 → 快捷按钮”可重新排序、编辑或删除快捷按钮。快捷按钮配置按项目分别保存。";
+"JSON import/export is supported for backing up or sharing your shortcut set." = "支持 JSON 导入/导出,便于备份或分享快捷按钮配置。";
+
+// Inspector Panel
+"Opening the Inspector Panel" = "打开检查器面板";
+"Click the sidebar.trailing (⊟) button at the top right of the toolbar to toggle the inspector panel. The panel docks to the right side of the window and contains two tabs: Terminal and Memo." = "点击工具栏右上角的 sidebar.trailing (⊟) 按钮可切换检查器面板。面板停靠到窗口右侧,包含“终端”和“备忘”两个选项卡。";
+"Terminal Tab" = "终端选项卡";
+"An embedded zsh terminal that opens at the current project's directory. Use it to run shell commands, inspect files, or manage git — all without leaving the app." = "内嵌的 zsh 终端,在当前项目目录下打开。可在其中运行 shell 命令、检查文件或管理 git,无需离开应用。";
+"Memo Tab" = "备忘选项卡";
+"A per-project rich text memo editor. Notes are auto-saved after a short pause and persist across sessions. Markdown formatting is supported." = "每个项目独立的富文本备忘编辑器。停止输入片刻后会自动保存,并在会话之间保留。支持 Markdown 格式。";
+"Heading levels (# / ## / ###)" = "标题级别 (# / ## / ###)";
+"Bold" = "加粗";
+"Italic" = "斜体";
+"Inline code" = "行内代码";
+"Strikethrough" = "删除线";
+"Unordered list (auto-continues on Return)" = "无序列表 (按回车自动延续)";
+"Interactive Terminal Popup" = "交互式终端弹窗";
+"Some slash commands (such as /config, /permissions, /model) open in a separate interactive terminal sheet. The popup runs the command automatically and closes when it exits." = "部分斜杠命令 (例如 /config、/permissions、/model) 会在独立的交互式终端面板中打开。弹窗会自动运行命令,在退出时关闭。";
+"The exit code is shown at the bottom — \"exit 0\" means the command completed successfully." = "底部显示退出码 — “exit 0” 表示命令成功完成。";
+
+// GitHub Integration
+"Click the GitHub Mark button at the top of the sidebar to open the GitHub panel. After connecting your GitHub account, your repositories are listed and can be added to Clarc with one click." = "点击侧栏顶部的 GitHub Mark 按钮可打开 GitHub 面板。连接 GitHub 账号后,你的仓库会列出,可一键添加到 Clarc。";
+"Adding a Repository" = "添加仓库";
+"Search for a repository by name, then click Add. Clarc clones it automatically and opens it as a new project." = "按名称搜索仓库,然后点击“添加”。Clarc 会自动克隆并作为新项目打开。";
+"Private repository" = "私有仓库";
+"Public repository" = "公开仓库";
+"Already added to Clarc" = "已添加到 Clarc";
+
+// Skill Marketplace
+"Click the brain icon (🧠) in the toolbar to browse the MCP plugin catalog published on Anthropic's GitHub. Plugins can be filtered by category or searched by name, description, or author." = "点击工具栏中的大脑图标 (🧠) 浏览 Anthropic 在 GitHub 上发布的 MCP 插件目录。可按分类筛选,也可按名称、描述或作者搜索。";
+"Installing Plugins" = "安装插件";
+"Click a plugin to view its details, then press Install. An interactive terminal popup opens and runs the install command automatically." = "点击插件查看详情,然后点击“安装”。交互式终端弹窗会自动打开并执行安装命令。";
+"Not installed" = "未安装";
+"Installing…" = "安装中…";
+"The catalog refreshes automatically every 5 minutes." = "目录每 5 分钟自动刷新一次。";
+
+// Status Line
+"What is the Status Line?" = "什么是状态栏?";
+"A fixed information bar at the bottom of the chat area. It shows the current project path, model, rate limit usage, context window usage, and total response time at a glance." = "对话区底部固定的信息栏。一眼即可查看当前项目路径、模型、速率限制用量、上下文窗口用量和总回复耗时。";
+"Displayed Items" = "显示项";
+"Items are shown left to right in the status line." = "状态栏中各项从左到右依次显示。";
+"Project path — folder path of the currently selected project (home directory abbreviated as ~)" = "项目路径 — 当前所选项目的文件夹路径 (主目录缩写为 ~)";
+"Model — name of the Claude model in use for this session" = "模型 — 本会话使用的 Claude 模型名称";
+"5h limit — API usage over the last 5 hours (bar + % + time until reset)" = "5h 限额 — 最近 5 小时的 API 用量 (进度条 + 百分比 + 距离重置的时间)";
+"7d limit — API usage over the last 7 days (bar + % + time until reset)" = "7d 限额 — 最近 7 天的 API 用量 (进度条 + 百分比 + 距离重置的时间)";
+"context — context window usage for the current session (bar + %)" = "context — 当前会话的上下文窗口用量 (进度条 + 百分比)";
+"Total response time — cumulative time Claude spent generating responses in this session" = "总回复耗时 — 本会话中 Claude 生成回复所花费的累计时间";
+"Usage Colors" = "用量颜色";
+"The bar graph and percentage change color based on usage level." = "进度条和百分比会根据用量等级改变颜色。";
+"Below 70% — normal" = "低于 70% — 正常";
+"70–89% — caution" = "70–89% — 注意";
+"90% or above — critical" = "90% 及以上 — 严重";
+"Usage data refreshes automatically after each response. If the initial fetch fails on launch, it retries once after 5 seconds." = "用量数据在每次回复后自动刷新。若启动时首次获取失败,会在 5 秒后重试一次。";
+
+// Permission Requests
+"What are Permission Requests?" = "什么是权限请求?";
+"Before Claude edits files or runs commands, it pauses and asks for your approval. A modal appears showing the tool name and its arguments." = "在 Claude 编辑文件或运行命令前会暂停并请求你的批准。弹窗会显示工具名称及其参数。";
+"Approval Options" = "批准选项";
+"Each permission request offers three choices." = "每个权限请求提供三个选项。";
+"Approve this single action" = "批准本次操作";
+"Approve all future requests of this type for the current session" = "批准本次会话中此类型的所有后续请求";
+"Reject the action" = "拒绝本次操作";
+"If no action is taken, the request is automatically denied after 5 minutes. Press Return to Allow, or Escape to Deny." = "若 5 分钟内未操作,请求会自动拒绝。按回车键为“允许”,按 Esc 键为“拒绝”。";
+// Permission Mode sections
+"Use the permission mode dropdown at the top of the chat to control how Claude requests approval before running actions." = "使用对话顶部的权限模式下拉框,控制 Claude 在执行操作前如何请求批准。";
+"Use the permission mode dropdown at the top of the chat to switch how Claude handles permissions." = "使用对话顶部的权限模式下拉框切换 Claude 处理权限的方式。";
+"Default — prompts for approval before file edits and commands" = "默认 — 在文件编辑和命令执行前请求批准";
+"Auto-accepts file edits in the working directory (commands still require approval)" = "自动接受工作目录内的文件编辑 (命令仍需批准)";
+"Read-only — analyzes and plans without making edits" = "只读 — 进行分析与规划,不做任何修改";
+"AI auto-approves safe operations, prompts only for risky ones (requires Max/Team/Enterprise/API plan + Sonnet/Opus 4.6+)" = "由 AI 自动批准安全操作,仅对风险操作进行提示 (需要 Max/Team/Enterprise/API 套餐以及 Sonnet/Opus 4.6+)";
+"Skips all permission checks — use only in isolated environments" = "跳过所有权限检查 — 仅在隔离环境中使用";
+"Skips all permission checks — writes to .git/.vscode/.claude directories still require approval" = "跳过所有权限检查 — 写入 .git/.vscode/.claude 目录的操作仍需批准";
+"Only enable Skip Permissions on projects you fully trust. Mode changes take effect from the next message." = "仅在完全信任的项目上启用“跳过权限检查”。模式变更从下一条消息起生效。";
+"Double-click" = "双击";
+
+"Skip Permissions Mode" = "跳过权限检查模式";
+"Toggle the shield icon at the top of the chat to auto-approve all permission requests. This speeds up tasks but also auto-executes potentially dangerous operations — use with caution." = "切换对话顶部的盾牌图标可自动批准所有权限请求。这能加快任务进度,但也会自动执行潜在危险操作 — 请谨慎使用。";
+
+
+// MARK: - UserManualView additions
+// Effort Level (Chat Basics)
+"Effort Level" = "思考强度";
+"Use the effort dropdown next to the model picker to control how much reasoning Claude applies. The selection is per-session." = "使用模型选择器旁的思考强度下拉框,控制 Claude 的推理力度。该选择按会话生效。";
+
+// Memo Tab formatting
+"Use the toolbar at the bottom for formatting, or the keyboard shortcuts below." = "使用底部工具栏进行格式设置,或使用以下键盘快捷键。";
+"Toggle checkbox" = "切换复选框";
+"Insert link" = "插入链接";
+"Underline" = "下划线";
+
+// Inspector Panel reset buttons
+"Reset Buttons" = "重置按钮";
+"Each inspector tab has a reset button (the circular arrow at the top right of the panel)." = "每个检查器选项卡都有一个重置按钮 (面板右上角的圆形箭头)。";
+"Reset Terminal" = "重置终端";
+"Clear Memo" = "清空备忘";
+"Terminate the current shell and start a fresh zsh session" = "终止当前 shell 并启动新的 zsh 会话";
+"Erase the memo for the current project (cannot be undone)" = "清空当前项目的备忘 (不可撤销)";
+
+// Hidden files toggle
+"Hidden Files" = "隐藏文件";
+"Toggle the eye icon in the Files tab header to show or hide dotfiles (files starting with a period, such as .env or .gitignore)." = "切换“文件”选项卡标题中的眼睛图标可显示或隐藏点开头的文件 (例如 .env 或 .gitignore)。";
+
+// Settings & Themes topic
+"Settings & Themes" = "设置与主题";
+"Opening Settings" = "打开设置";
+"Choose Clarc → Settings from the menu bar or press ⌘, to open the Settings window. Settings are organized into three tabs: General, Slash Commands, and Shortcuts." = "从菜单栏选择“Clarc → 设置”,或按 ⌘, 打开设置窗口。设置分为三个选项卡:通用、斜杠命令、快捷按钮。";
+"General Tab" = "通用选项卡";
+"The General tab configures session defaults. Changes apply to newly created sessions — existing sessions keep their current values." = "“通用”选项卡用于配置会话默认值。变更仅对新创建的会话生效,已有会话保持当前值。";
+"Accent color palette (Terracotta, Ocean, Forest, Lavender, Midnight, Amber)" = "主题色板 (赤陶、海洋、森林、薰衣草、午夜、琥珀)";
+"Claude model used when starting a new session" = "新建会话时使用的 Claude 模型";
+"Permission mode applied to new sessions" = "应用于新会话的权限模式";
+"Reasoning effort applied to new sessions" = "应用于新会话的推理强度";
+"Show a system notification when a response completes while Clarc is in the background" = "Clarc 在后台且回复完成时,显示系统通知";
+"Model, permission mode, and effort can also be overridden per session from the toolbar — the chosen value sticks to that session." = "模型、权限模式和思考强度也可以在工具栏按会话单独覆盖 — 所选值会固定到该会话。";
+"Themes" = "主题";
+"Clarc ships with six accent color themes. Preview each one directly from the theme picker — the whole app recolors live as you choose." = "Clarc 提供六种主题色。可在主题选择器中直接预览,选定后整个应用实时换色。";
+"Terracotta" = "赤陶";
+"Ocean" = "海洋";
+"Forest" = "森林";
+"Lavender" = "薰衣草";
+"Midnight" = "午夜";
+"Amber" = "琥珀";
+"Claude default — warm orange-red" = "Claude 默认 — 暖橙红色";
+"Cool blue" = "冷蓝色";
+"Deep green" = "深绿色";
+"Soft purple" = "柔紫";
+"Dark indigo" = "深靛蓝";
+"Warm yellow" = "暖黄色";
+"Slash Commands & Shortcuts Tabs" = "斜杠命令与快捷按钮选项卡";
+"The other two Settings tabs manage per-project slash commands and shortcut buttons. Slash command JSON import/export includes custom commands only; shortcut JSON import/export backs up the shortcut set." = "另外两个设置选项卡用于管理各项目的斜杠命令和快捷按钮。斜杠命令的 JSON 导入/导出仅包含自定义命令;快捷按钮的 JSON 导入/导出则用于备份整套快捷按钮。";
+"Checking for Updates" = "检查更新";
+"Open Clarc → Check for Updates… to run Sparkle's update check manually. Updates are also checked automatically on launch." = "打开“Clarc → 检查更新…”可手动运行 Sparkle 的更新检查。启动时也会自动检查更新。";

--- a/Clarc/Services/ClaudeService.swift
+++ b/Clarc/Services/ClaudeService.swift
@@ -70,6 +70,13 @@ actor ClaudeService {
     /// cannot locate Node.
     private var cachedShellPath: String?
 
+    /// Cached env dictionary exported by the user's interactive login shell.
+    /// Built once on first use. macOS GUI processes do not inherit the
+    /// user's `~/.zshrc` exports, so third-party routing variables
+    /// (e.g. `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`) silently disappear
+    /// unless we re-read the login shell.
+    private var cachedShellEnv: [String: String]?
+
     /// Compose a PATH that lets the spawned `claude` CLI find `node` and
     /// related tools regardless of where the user installed them.
     ///
@@ -146,12 +153,52 @@ actor ClaudeService {
         return nil
     }
 
-    /// Build the full environment dictionary for spawned subprocesses,
-    /// inheriting the GUI environment but with PATH replaced by ``resolvedShellPath()``.
+    /// Build the full environment dictionary for spawned subprocesses.
+    ///
+    /// Starts from the GUI process's env, then layers the user's login shell
+    /// exports on top so that third-party routing variables
+    /// (e.g. `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`) reach the spawned
+    /// `claude` CLI. PATH is always overridden with ``resolvedShellPath()``
+    /// since the curated PATH survives the GUI launch context better than
+    /// the raw shell PATH for this use case.
     private func resolvedEnvironment() async -> [String: String] {
         var env = ProcessInfo.processInfo.environment
+        if let shellEnv = await readUserShellEnv() {
+            for (key, value) in shellEnv where key != "PATH" { env[key] = value }
+        }
         env["PATH"] = await resolvedShellPath()
         return env
+    }
+
+    /// Read all env vars exported by the user's interactive login shell.
+    ///
+    /// Uses `zsh -ilc "env -0"` so the user's `.zshrc` (and `nvm`/`asdf` init
+    /// it typically sources) is loaded and `export FOO=bar` lines are visible.
+    /// The `-0` flag produces NUL-separated records, robust to spaces and
+    /// newlines inside values. Result is cached for the service lifetime.
+    private func readUserShellEnv() async -> [String: String]? {
+        if let cached = cachedShellEnv { return cached }
+        do {
+            let output = try await runShellCommand(
+                "/bin/zsh",
+                arguments: ["-ilc", "env -0"],
+                injectPath: false
+            )
+            var parsed: [String: String] = [:]
+            for entry in output.split(separator: "\0", omittingEmptySubsequences: true) {
+                guard let eq = entry.firstIndex(of: "=") else { continue }
+                let key = String(entry[..<eq])
+                let value = String(entry[entry.index(after: eq)...])
+                parsed[key] = value
+            }
+            if parsed.isEmpty { return nil }
+            cachedShellEnv = parsed
+            logger.info("Resolved shell env for subprocess (entries=\(parsed.count))")
+            return parsed
+        } catch {
+            logger.warning("Failed to read user shell env: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     // MARK: - Binary Discovery

--- a/Packages/Sources/ClarcChatKit/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Sources/ClarcChatKit/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,34 @@
+/* Simplified Chinese — zh-Hans localization for ClarcChatKit */
+
+// MARK: - ToolResultView
+"Show less" = "收起";
+"Show more" = "展开";
+
+// MARK: - SlashCommandManagerView
+"Imported %lld custom commands." = "已导入 %lld 条自定义命令。";
+"A command with this name already exists." = "已存在同名的命令。";
+"Restore modified default commands to their original state" = "将已修改的默认命令恢复到原始状态";
+"All modified default commands will be restored to their original state." = "所有已修改的默认命令都将恢复到原始状态。";
+"Clarc slash command export file." = "Clarc 斜杠命令导出文件。";
+"Usage:" = "用法:";
+"Edit the array below to add, remove, or change custom slash commands." = "编辑下方的数组,以添加、删除或修改自定义斜杠命令。";
+"The leading slash is optional while editing names; Clarc saves names without it." = "编辑名称时,前导斜杠是可选的;Clarc 保存时不会带斜杠。";
+"Built-in command names are ignored on import and are never exported." = "导入时会忽略内置命令名称,且不会导出内置命令。";
+"Each custom command supports these properties:" = "每个自定义命令支持以下属性:";
+"name: command name without the leading slash." = "name: 不带前导斜杠的命令名称。";
+"description: short text shown in the command picker." = "description: 显示在命令选择器中的简短说明。";
+"detailDescription: optional longer text shown in command details. Use null or omit it when empty." = "detailDescription: 显示在命令详情中的可选长说明。留空时使用 null 或省略。";
+"acceptsInput: true lets users type additional text after the command." = "acceptsInput: 设为 true 时,允许在命令后输入额外文本。";
+"isInteractive: true runs the command in the interactive terminal." = "isInteractive: 设为 true 时,在交互式终端中执行该命令。";
+"All properties example:" = "所有属性示例:";
+"Short description shown in the command picker" = "显示在命令选择器中的简短说明";
+"Optional longer description shown in command details" = "显示在命令详情中的可选长说明";
+"Clarc shortcut export file." = "Clarc 快捷按钮导出文件。";
+"Edit the array below to add, remove, or change shortcuts." = "编辑下方的数组,以添加、删除或修改快捷按钮。";
+"Each shortcut supports these properties:" = "每个快捷按钮支持以下属性:";
+"id: optional unique identifier (UUID). Auto-generated on import if omitted." = "id: 可选的唯一标识 (UUID)。导入时若省略则自动生成。";
+"name: label shown on the shortcut button." = "name: 显示在快捷按钮上的名称。";
+"message: text sent to Claude, or command run in the terminal." = "message: 发送给 Claude 的文本,或在终端中执行的命令。";
+"isTerminalCommand: true runs the message as a terminal command instead of sending it to chat." = "isTerminalCommand: 设为 true 时,将消息作为终端命令执行,而不是发送到对话。";
+"Shortcut button label" = "快捷按钮名称";
+"Message sent to Claude or command run in terminal" = "发送给 Claude 的消息或在终端中执行的命令";


### PR DESCRIPTION
# Add Simplified Chinese (zh-Hans) localization and fix shell env passthrough

This PR contains two small, independent changes that make Clarc usable in more environments.

## 1. Add zh-Hans (Simplified Chinese) localization

- `Clarc/Resources/zh-Hans.lproj/Localizable.strings` — 413 keys
- `Packages/Sources/ClarcChatKit/Resources/zh-Hans.lproj/Localizable.strings` — 29 keys
- `Clarc.xcodeproj/project.pbxproj` — added `zh-Hans` to `knownRegions`

Brings Clarc to parity with the existing `en` and `ko` localizations. Brand names (Clarc, Claude Code, GitHub) are kept as English. Both files pass `plutil -lint` and translate 1:1 against the `en.lproj` base.

Future notes for the maintainer: if you continue to commit `en.lproj` and `ko.lproj` together, please consider also updating `zh-Hans` (this fork is standalone; there is no auto-sync script on my side).

## 2. Pass user shell env to spawned Claude CLI

`Clarc/Services/ClaudeService.swift` — new `readUserShellEnv()` helper and `resolvedEnvironment()` now layers the user's login shell exports on top of the GUI process env before spawning the `claude` subprocess.

**Why this matters:** macOS GUI apps do not inherit the user's `~/.zshrc` exports. The existing `resolvedShellPath()` already works around this for PATH, but any other third-party routing variables (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, etc.) silently disappear when Clarc spawns the CLI. The CLI then falls back to OAuth login and third-party API endpoints stop working — which is exactly what happens with the routing setups many power users configure.

**Fix:** read all env vars exported by the user's login shell (`zsh -ilc "env -0"`, so `.zshrc` and any `nvm`/`asdf` init it sources are loaded), NUL-separated to preserve spaces and newlines, and cache the result for the service lifetime. PATH is still overridden last with the curated `resolvedShellPath()` so the existing node-resolution fix is preserved. Mirrors the same one-shot read + cache pattern already used for PATH.

## Test plan

- [x] `plutil -lint` on both new `.strings` files — OK
- [x] Validated that every `en.lproj` key has a corresponding `zh-Hans.lproj` translation (413/413 in main app, 29/29 in ClarcChatKit; brand names "Claude Code" and "GitHub" kept as English)
- [x] `swiftc -parse` on the modified `ClaudeService.swift` (no Xcode available in dev env)
- [x] Two commits on `i18n-zh-Hans-and-shell-env`:
  - `feat(i18n): add Simplified Chinese (zh-Hans) localization`
  - `fix(cli): pass user shell env to spawned Claude CLI`
- [ ] Manual test on macOS: set `ANTHROPIC_BASE_URL` in `~/.zshrc`, launch Clarc, confirm CLI uses the routed endpoint instead of falling back to OAuth

Happy to split into two PRs if the maintainer prefers; the changes are logically independent.
